### PR TITLE
Travisで複数バージョンのRubyを使うようにする

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 ---
 sudo: false
+dist: xenial
 language: ruby
 cache: bundler
 rvm:
-  - 2.3.3
-before_install: gem install bundler -v 2.0.1
+  - ruby-head
+  - 2.6
+  - 2.5
+  - 2.4
+  - 2.3
+
+before_install:
+  - gem update bundler

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
-# Test::Unit::Runner::Junitxml
+# Test::Unit::Runner::JUnitXml
+
+[![Build Status](https://travis-ci.org/kenichiice/test-unit-runner-junitxml.svg?branch=master)](https://travis-ci.org/kenichiice/test-unit-runner-junitxml)
 
 WIP


### PR DESCRIPTION
Travisで複数バージョンのRubyを使うようにします。

また、Ubuntu Xenial 16.04を使用するようにします。