### PR TITLE
依存関係からバージョンを削除する

### DIFF
--- a/test-unit-runner-junitxml.gemspec
+++ b/test-unit-runner-junitxml.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
   #spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
 
-  spec.add_runtime_dependency "test-unit", "~> 3.0"
+  spec.add_runtime_dependency "test-unit"
 end


### PR DESCRIPTION
Ruby 2.6にバンドルされているBundlerは2.0より低いバージョンなので、Bundler 2.0互換の指定はよくない。

ひとまず、gemspecからバージョンの指定は削除する。