### PR TITLE
環境依存のエラーを解決する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,9 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true    
+        bundler-cache: true
     # - run: bundle install
-    - run: bundle exec rake test
+    - if: matrix.ruby != 'jruby'
+      run: bundle exec rake test
+    - if: matrix.ruby == 'jruby'
+      run: bundle exec rake test TESTOPTS='--ignore-name=/multibyte/'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,10 @@ jobs:
         ruby: [head, 2.7, 2.6, 2.5, 2.4, 2.3, jruby, truffleruby]
         exclude:
           - os: windows-latest
+            ruby: 2.4
+          - os: windows-latest
+            ruby: 2.3
+          - os: windows-latest
             ruby: truffleruby
     runs-on: ${{ matrix.os }}
     # continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,9 @@
 require "bundler/gem_tasks"
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "lib"
+  t.test_files = FileList['test/**/test*.rb']
+end
 
 task :default => :test
-
-desc "run unit tests"
-task :test do
-    ruby("test/run-test.rb")
-end

--- a/test-unit-runner-junitxml.gemspec
+++ b/test-unit-runner-junitxml.gemspec
@@ -1,4 +1,3 @@
-
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "test/unit/runner/junitxml/version"
@@ -25,6 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "rexml"
 
   spec.add_runtime_dependency "test-unit"
 end


### PR DESCRIPTION
GitHub Actionsでエラーが発生している次の環境でエラーが起こらないようにする。
1. ruby-head (2.8)
2. jruby
3. ruby 2.4, 2.3 on windows

