### PR TITLE
<error>と<failure>内の余計な改行とタブを削除

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -33,15 +33,13 @@ $ ruby test.rb --runner=junitxml --junitxml-output-file=result.xml
 $ cat result.xml
 <?xml version="1.0" encoding="UTF-8" ?>
 <testsuites>
-	<testsuite name="MyTest" tests="1" errors="0" failures="1" skipped="0" time="0.0047083">
-		<testcase classname="MyTest" name="test_1(MyTest)" time="0.0046712" assertions="1">
+	<testsuite name="MyTest" tests="1" errors="0" failures="1" skipped="0" time="0.005365">
+		<testcase classname="MyTest" name="test_1(MyTest)" time="0.0053308" assertions="1">
 			<failure message="&lt;1&gt; expected but was
-&lt;2&gt;.">
-Failure:
+&lt;2&gt;.">Failure:
 test_1(MyTest) [test.rb:7]:
 &lt;1&gt; expected but was
-&lt;2&gt;.
-			</failure>
+&lt;2&gt;.</failure>
 			<system-out>hello</system-out>
 		</testcase>
 	</testsuite>

--- a/README.md
+++ b/README.md
@@ -33,15 +33,13 @@ $ ruby test.rb --runner=junitxml --junitxml-output-file=result.xml
 $ cat result.xml
 <?xml version="1.0" encoding="UTF-8" ?>
 <testsuites>
-	<testsuite name="MyTest" tests="1" errors="0" failures="1" skipped="0" time="0.0047083">
-		<testcase classname="MyTest" name="test_1(MyTest)" time="0.0046712" assertions="1">
+	<testsuite name="MyTest" tests="1" errors="0" failures="1" skipped="0" time="0.005365">
+		<testcase classname="MyTest" name="test_1(MyTest)" time="0.0053308" assertions="1">
 			<failure message="&lt;1&gt; expected but was
-&lt;2&gt;.">
-Failure:
+&lt;2&gt;.">Failure:
 test_1(MyTest) [test.rb:7]:
 &lt;1&gt; expected but was
-&lt;2&gt;.
-			</failure>
+&lt;2&gt;.</failure>
 			<system-out>hello</system-out>
 		</testcase>
 	</testsuite>

--- a/lib/test/unit/ui/junitxml/xml.erb
+++ b/lib/test/unit/ui/junitxml/xml.erb
@@ -5,13 +5,9 @@
 %	test_suite.test_cases.each do |test_case|
 		<testcase classname="<%=h test_case.class_name %>" name="<%=h test_case.name %>" time="<%=h test_case.time %>" assertions="<%=h test_case.assertion_count %>">
 %		if test_case.error
-			<error message="<%=h test_case.error.message %>" type="<%=h test_case.error.exception.class.name %>">
-<%=h test_case.error.long_display %>
-			</error>
+			<error message="<%=h test_case.error.message %>" type="<%=h test_case.error.exception.class.name %>"><%=h test_case.error.long_display %></error>
 %		elsif test_case.failure
-			<failure message="<%=h test_case.failure.message %>">
-<%=h test_case.failure.long_display %>
-			</failure>
+			<failure message="<%=h test_case.failure.message %>"><%=h test_case.failure.long_display %></failure>
 %		elsif test_case.omission
 			<skipped message="<%=h test_case.omission.message %>"/>
 %		elsif test_case.pending


### PR DESCRIPTION
出力するXMLの `<error>` と `<failure>` に余計な改行とタブが含まれないように変更します。
