### PR TITLE
インスタンス変数未初期化の警告が出力されないように修正

### DIFF
--- a/lib/test/unit/ui/junitxml/testrunner.rb
+++ b/lib/test/unit/ui/junitxml/testrunner.rb
@@ -133,6 +133,7 @@ module Test
           def initialize(class_name, name)
             @class_name = class_name
             @name = name
+            @failure = @error = @omission = @pending = nil
             @stdout = StringIO.new
             @stderr = StringIO.new
             @assertion_count = 0


### PR DESCRIPTION
Ruby 2.7などで実行すると

    warning: instance variable @omission not initialized
    warning: instance variable @pending not initialized

といった警告が出力されるようになってしまっていたので修正します。