### PR TITLE
ActionsでWindows上でのRuby 3.1実行を有効にする

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,6 @@ jobs:
         ruby: [head, 3.1, 3.0, 2.7, 2.6, jruby, truffleruby]
         exclude:
           - os: windows-latest
-            ruby: 3.1
-          - os: windows-latest
             ruby: truffleruby
     runs-on: ${{ matrix.os }}
     # continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}


### PR DESCRIPTION
ruby/setup-ruby がWindows上でのRuby 3.1の使用をサポートしたようなので使うようにします。