### PR TITLE
 ActionsでWindows上でのJRuby実行を無効にする

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
         ruby: [head, 3.1, 3.0, 2.7, 2.6, jruby, truffleruby]
         exclude:
           - os: windows-latest
+            ruby: jruby
+          - os: windows-latest
             ruby: truffleruby
     runs-on: ${{ matrix.os }}
     # continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}


### PR DESCRIPTION
Windows版JRubyではテストが失敗することが多いので、Actionsでの実行対象外とします。
テストが失敗するのはタイマーの解像度が低いからではないかと考えています（テストの実行時間が0になってしまうことがあり、それによりテストが失敗している）。