### PR TITLE
XMLのインデントを修正

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -33,8 +33,8 @@ $ ruby test.rb --runner=junitxml --junitxml-output-file=result.xml
 $ cat result.xml
 <?xml version="1.0" encoding="UTF-8" ?>
 <testsuites>
-	<testsuite name="MyTest" tests="1" errors="0" failures="1" skipped="0" time="0.005365">
-		<testcase classname="MyTest" name="test_1(MyTest)" time="0.0053308" assertions="1">
+	<testsuite name="MyTest" tests="1" errors="0" failures="1" skipped="0" time="0.0037614">
+		<testcase classname="MyTest" name="test_1(MyTest)" file="test.rb" time="0.0036311" assertions="1">
 			<failure message="&lt;1&gt; expected but was
 &lt;2&gt;.">Failure:
 test_1(MyTest) [test.rb:7]:

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ $ ruby test.rb --runner=junitxml --junitxml-output-file=result.xml
 $ cat result.xml
 <?xml version="1.0" encoding="UTF-8" ?>
 <testsuites>
-	<testsuite name="MyTest" tests="1" errors="0" failures="1" skipped="0" time="0.005365">
-		<testcase classname="MyTest" name="test_1(MyTest)" time="0.0053308" assertions="1">
+	<testsuite name="MyTest" tests="1" errors="0" failures="1" skipped="0" time="0.0037614">
+		<testcase classname="MyTest" name="test_1(MyTest)" file="test.rb" time="0.0036311" assertions="1">
 			<failure message="&lt;1&gt; expected but was
 &lt;2&gt;.">Failure:
 test_1(MyTest) [test.rb:7]:

--- a/lib/test/unit/ui/junitxml/xml.erb
+++ b/lib/test/unit/ui/junitxml/xml.erb
@@ -3,7 +3,7 @@
 % @junit_test_suites.each do |test_suite|
 	<testsuite name="<%=h test_suite.name %>" tests="<%=h test_suite.test_cases.size %>" errors="<%=h test_suite.errors.size %>" failures="<%=h test_suite.failures.size %>" skipped="<%=h test_suite.test_cases.count(&:skipped?) %>" time="<%=h test_suite.time %>">
 %	test_suite.test_cases.each do |test_case|
-                <testcase classname="<%=h test_case.class_name %>" name="<%=h test_case.name %>" file="<%=h test_case.file%>" time="<%=h test_case.time %>" assertions="<%=h test_case.assertion_count %>">
+		<testcase classname="<%=h test_case.class_name %>" name="<%=h test_case.name %>" file="<%=h test_case.file%>" time="<%=h test_case.time %>" assertions="<%=h test_case.assertion_count %>">
 %		if test_case.error
 			<error message="<%=h test_case.error.message %>" type="<%=h test_case.error.exception.class.name %>"><%=h test_case.error.long_display %></error>
 %		elsif test_case.failure


### PR DESCRIPTION
生成するXMLはタブを使ってインデントするようにしていますが、空白が混ざっていたのでタブに統一します。

また、READMEにあるXMLの出力例にfile属性を追加します。