### PR TITLE
テスト対象とするRubyのバージョンとactions/checkoutを更新

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     # continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,11 @@ jobs:
           - os: windows-latest
             ruby: jruby
           - os: windows-latest
+            ruby: jruby-head
+          - os: windows-latest
             ruby: truffleruby
+          - os: windows-latest
+            ruby: truffleruby-head
     runs-on: ${{ matrix.os }}
     # continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,15 @@ on:
   schedule:
     - cron: '34 18 * * *'
 jobs:
+  ruby-versions:
+    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
   rake-test:
+    needs: ruby-versions
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: [head, 3.1, 3.0, 2.7, 2.6, jruby, truffleruby]
+        ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         exclude:
           - os: windows-latest
             ruby: jruby


### PR DESCRIPTION
ruby/actions/.github/workflows/ruby_versions.yml　を使って、テスト対象のRubyのバージョンが自動的に更新されるようにします。
* see [Ruby の新しいバージョンがリリースされても自動で GitHub Actions の対象とするやつを作った](https://www.hsbt.org/diary/20230215.html#p02)

また、actions/checkout を v3 に更新します。