### PR TITLE
JRuby上でのマルチバイトテスト名のテスト除外をやめる

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,4 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    # - run: bundle install
-    - if: matrix.ruby != 'jruby'
-      run: bundle exec rake test
-    - if: matrix.ruby == 'jruby'
-      run: bundle exec rake test TESTOPTS='--ignore-testcase=TestXmlMultibyteName'
+    - run: bundle exec rake test


### PR DESCRIPTION
#6 にて、JRuby上ではマルチバイト文字列をテスト名に含むテストを実行しないようにしていた。
が、現在ではJRuby上でも正しく動作するようなので、このテストをJRuby上でも実行するように変更する。