### PR TITLE
Add an action for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+on:
+  push:
+    tags:
+      - "v*"
+jobs:
+  push:
+    name: Push gem to RubyGems.org
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+      contents: write # IMPORTANT: this permission is required for `rake release` to push the release tag
+
+    environment: release
+
+    steps:
+      # Set up
+      - uses: actions/checkout@v4.2.2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+
+      # Release
+      - uses: rubygems/release-gem@v1.1.1

--- a/lib/test/unit/runner/junitxml/version.rb
+++ b/lib/test/unit/runner/junitxml/version.rb
@@ -2,7 +2,7 @@ module Test
   module Unit
     module Runner
       module Junitxml
-        VERSION = "1.0.0"
+        VERSION = "1.0.1"
       end
     end
   end


### PR DESCRIPTION
I will add the workflow `release.yml` to handle the release process.

This PR also serves as an experiment, so the release of v1.0.1 will likely be done within this PR.

* The release process will be triggered when a release tag is assigned.
* It uses the [Trusted Publishing](https://guides.rubygems.org/trusted-publishing/) mechanism of RubyGems.org.
* A [GitHub environment](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/managing-environments-for-deployment) named `release` has been created for the release process.