### PR TITLE
actions/checkout に persist-credentials オプションを追加する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,8 @@ jobs:
     # continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
[actions/checkout](https://github.com/actions/checkout) の `persist-credentials` オプションは `false` に設定すべきという文書を呼んだので、`false` に設定するPRを作りました。

* [GitHub Actions】actions/checkout には persist-credentials: false を設定するべき](https://zenn.dev/kou_pg_0131/articles/gha-checkout-persist-credentials)

git は checkout するときにしか使わないはずなので副作用はないはずだと考えています。