### PR TITLE
release.yml の actions/checkout に persist-credentials オプションを追加する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       # Set up
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,11 +28,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     # continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}
     steps:
-    - uses: actions/checkout@v6
-      with:
-        persist-credentials: false
-    - uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
-    - run: bundle exec rake test
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake test


### PR DESCRIPTION
#33 は test.yml しか修正していませんでした。

release.yml も actions/checkout を使っているので、同様に `persist-credentials` を `false` に設定するPRを作成しました。

このアクションは [release-gem](https://github.com/rubygems/release-gem) を使用していますが、release-gem のREADMEに `persist-credentials` を `false` に設定する例が書かれているので問題ないと考えています。